### PR TITLE
Added `static_bundled_build` feature, imported readme into the crate documention

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 # Core
-fermium = { version  = "22605", default-features = false }
+fermium = { version = "22605", default-features = false }
 glow = "0.14"
 bytemuck = { version = "1.9", features = ["derive"] }
 glam = { version = "0.28", features = ["bytemuck"] }
@@ -24,3 +24,4 @@ rand = "0.8"
 [features]
 default = ["ldtk"]
 ldtk = ["serde", "serde_json"]
+static_bundled_build = ["fermium/static_bundled_build"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@ on between 2018 and 2022. It aims to be smaller and simpler, with less global st
 
 **⚠️ Use at your own risk!** This framework is still very experimental, and the API is constantly in flux. No support is offered, but you are welcome to use to the code as reference or fork it for your own needs.
 
+## Features
+
+- `ldtk` (enabled by default): enables a module to load [ldtk](https://ldtk.io/) files.
+- `static_bundled_build`: enables automatic SDL2 library building and linking. Building SDL2 can take a bit during that first build (usually 1 minute or more).
+
 ## Notes
 
-* This framework is very heavily inspired by [FNA](https://github.com/FNA-XNA/FNA), and NoelFB's lightweight game engines ([Blah](https://github.com/NoelFB/blah) and [Foster](https://github.com/NoelFB/Foster)).
-* It depends on [SDL2](https://www.libsdl.org/) for interacting with the underlying platform.
+- This framework is very heavily inspired by [FNA](https://github.com/FNA-XNA/FNA), and NoelFB's lightweight game engines ([Blah](https://github.com/NoelFB/blah) and [Foster](https://github.com/NoelFB/Foster)).
+- It depends on [SDL2](https://www.libsdl.org/) for interacting with the underlying platform.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::new_without_default)]
+#![doc = include_str!("../README.md")]
 
 // ===== Core =====
-
 pub mod app;
 pub mod fs;
 pub mod graphics;


### PR DESCRIPTION
From the fermium documentation:

> If you use the static_bundled_build cargo feature then this will build SDL2 using a bundled copy of the source and then statically link to that. Building SDL2 can take a bit during that first build (usually 1 minute or more).

Makes us windows developers' lives a bit easier