### PR TITLE
Added 'canvas::into_texture'

### DIFF
--- a/src/graphics/canvas.rs
+++ b/src/graphics/canvas.rs
@@ -38,6 +38,10 @@ impl Canvas {
     pub fn size(&self) -> (i32, i32) {
         self.texture.size()
     }
+
+    pub fn into_texture(self) -> Texture {
+        self.texture
+    }
 }
 
 pub struct RawCanvas {


### PR DESCRIPTION
Using the canvas to make textures at runtime, I noticed a developer has to do
```rs
return MyObject {
  texture: canvas.texture.clone()
}
```

However the canvas is dropped immediately after. It would be more ergonomic to be able to extract the texture from the canvas directly