### PR TITLE
Created intermediate enum for events

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -9,8 +9,8 @@ mod shader;
 mod text;
 mod texture;
 
-use std::cell::Cell;
 use std::rc::Rc;
+use std::{cell::Cell, sync::Arc};
 
 use glam::Mat4;
 use glow::{Context, HasContext};
@@ -28,7 +28,7 @@ pub use texture::*;
 use crate::window::Window;
 
 struct State {
-    gl: Context,
+    gl: Arc<Context>,
 
     current_vertex_buffer: Cell<Option<glow::Buffer>>,
     current_index_buffer: Cell<Option<glow::Buffer>>,
@@ -65,7 +65,7 @@ impl Graphics {
 
         Graphics {
             state: Rc::new(State {
-                gl,
+                gl: Arc::new(gl),
                 current_vertex_buffer: Cell::new(None),
                 current_index_buffer: Cell::new(None),
                 current_shader: Cell::new(None),
@@ -227,6 +227,15 @@ impl Graphics {
                 self.state.current_canvas.set(canvas);
             }
         }
+    }
+
+    /// Get the raw OpenGL context.
+    ///
+    /// # Safety
+    ///
+    /// You have full access to the raw OpenGL context, so you can do anything you want with it.
+    pub unsafe fn gl(&self) -> &Arc<Context> {
+        &self.state.gl
     }
 }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -30,6 +30,7 @@ use crate::window::Window;
 struct State {
     gl: Arc<Context>,
 
+    vao: glow::NativeVertexArray,
     current_vertex_buffer: Cell<Option<glow::Buffer>>,
     current_index_buffer: Cell<Option<glow::Buffer>>,
     current_shader: Cell<Option<glow::Program>>,
@@ -46,8 +47,9 @@ impl Graphics {
     pub fn new(window: &mut Window) -> Graphics {
         let gl = window.load_gl();
 
+        let vao: glow::NativeVertexArray;
         unsafe {
-            let vao = gl.create_vertex_array().unwrap();
+            vao = gl.create_vertex_array().unwrap();
             gl.bind_vertex_array(Some(vao));
 
             gl.enable(glow::CULL_FACE);
@@ -66,6 +68,8 @@ impl Graphics {
         Graphics {
             state: Rc::new(State {
                 gl: Arc::new(gl),
+
+                vao,
                 current_vertex_buffer: Cell::new(None),
                 current_index_buffer: Cell::new(None),
                 current_shader: Cell::new(None),
@@ -94,6 +98,7 @@ impl Graphics {
         unsafe {
             pass.target.bind(self);
 
+            self.state.gl.bind_vertex_array(Some(self.state.vao));
             self.bind_vertex_buffer(Some(pass.mesh.raw.vertex_buffer));
             self.bind_index_buffer(Some(pass.mesh.raw.index_buffer));
             self.bind_shader(Some(pass.shader.raw.id));
@@ -236,6 +241,20 @@ impl Graphics {
     /// You have full access to the raw OpenGL context, so you can do anything you want with it.
     pub unsafe fn gl(&self) -> &Arc<Context> {
         &self.state.gl
+    }
+
+    /// Rebind everything to the current state.
+    ///
+    /// You should never need to call this, unless you're manipulating `.gl()` directly
+    pub fn rebind(&self) {
+        unsafe {
+            self.state.gl.bind_vertex_array(Some(self.state.vao));
+        }
+        self.bind_vertex_buffer(self.state.current_vertex_buffer.take());
+        self.bind_index_buffer(self.state.current_index_buffer.take());
+        self.bind_shader(self.state.current_shader.take());
+        self.bind_texture(self.state.current_texture.take());
+        self.bind_canvas(self.state.current_canvas.take());
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -87,6 +87,7 @@ impl Input {
                     self.axes.set_value(*gamepad_id, *axis, *value);
                 }
             }
+            Event::WindowResized { .. } => {}
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -87,7 +87,7 @@ impl Input {
                     self.axes.set_value(*gamepad_id, *axis, *value);
                 }
             }
-            Event::WindowResized { .. } => {}
+            Event::WindowResized { .. } | Event::TextInput { .. } => {}
         }
     }
 

--- a/src/input/event.rs
+++ b/src/input/event.rs
@@ -1,0 +1,165 @@
+use fermium::prelude::*;
+use glam::Vec2;
+
+/// This is a unique ID for a joystick for the time it is connected to the
+/// system.
+///
+/// It is never reused for the lifetime of the application. If the joystick is
+/// disconnected and reconnected, it will get a new ID.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct JoystickID(SDL_JoystickID);
+
+impl JoystickID {
+    fn from_raw(id: i32) -> JoystickID {
+        JoystickID(SDL_JoystickID(id))
+    }
+    fn from_controller_handle(handle: *mut SDL_GameController) -> JoystickID {
+        unsafe {
+            JoystickID(SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(
+                handle,
+            )))
+        }
+    }
+}
+
+use super::{Gamepad, GamepadAxis, GamepadButton, Key, MouseButton};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    KeyDown(Key),
+    KeyUp(Key),
+    MouseButtonDown(MouseButton),
+    MouseButtonUp(MouseButton),
+    MouseMotion {
+        new_position: Vec2,
+    },
+    ControllerDeviceAdded {
+        joystick: JoystickID,
+        gamepad: Gamepad,
+    },
+    ControllerDeviceRemoved {
+        joystick: JoystickID,
+    },
+
+    ControllerButtonDown {
+        joystick: JoystickID,
+        button: GamepadButton,
+    },
+    ControllerButtonUp {
+        joystick: JoystickID,
+        button: GamepadButton,
+    },
+
+    ControllerAxisMotion {
+        joystick: JoystickID,
+        axis: GamepadAxis,
+        value: f32,
+    },
+}
+
+impl Event {
+    pub fn try_from_sdl_event(event: &SDL_Event) -> Option<Self> {
+        unsafe {
+            match event.type_ {
+                SDL_KEYDOWN if event.key.repeat == 0 => {
+                    if let Some(key) = Key::from_raw(event.key.keysym.scancode) {
+                        return Some(Event::KeyDown(key));
+                    }
+                }
+
+                SDL_KEYUP if event.key.repeat == 0 => {
+                    if let Some(key) = Key::from_raw(event.key.keysym.scancode) {
+                        return Some(Event::KeyUp(key));
+                    }
+                }
+
+                SDL_MOUSEBUTTONDOWN => {
+                    if let Some(button) = MouseButton::from_raw(event.button.button as u32) {
+                        return Some(Event::MouseButtonDown(button));
+                    }
+                }
+
+                SDL_MOUSEBUTTONUP => {
+                    if let Some(button) = MouseButton::from_raw(event.button.button as u32) {
+                        return Some(Event::MouseButtonUp(button));
+                    }
+                }
+
+                SDL_MOUSEMOTION => {
+                    return Some(Event::MouseMotion {
+                        new_position: Vec2::new(event.motion.x as f32, event.motion.y as f32),
+                    });
+                }
+
+                SDL_CONTROLLERDEVICEADDED => {
+                    let handle = SDL_GameControllerOpen(event.cdevice.which);
+
+                    if handle.is_null() {
+                        // TODO: Should probably log here
+                        return None;
+                    }
+
+                    let joystick = JoystickID::from_controller_handle(handle);
+
+                    let gamepad = Gamepad::from_raw(handle);
+
+                    return Some(Event::ControllerDeviceAdded { joystick, gamepad });
+                }
+
+                SDL_CONTROLLERDEVICEREMOVED => {
+                    return Some(Event::ControllerDeviceRemoved {
+                        joystick: JoystickID::from_raw(event.cdevice.which),
+                    });
+                }
+
+                SDL_CONTROLLERBUTTONDOWN => {
+                    if let Some(button) = GamepadButton::from_raw(SDL_GameControllerButton(
+                        event.cbutton.button as i32,
+                    )) {
+                        return Some(Event::ControllerButtonDown {
+                            joystick: JoystickID::from_raw(event.cdevice.which),
+                            button,
+                        });
+                    }
+                }
+
+                SDL_CONTROLLERBUTTONUP => {
+                    if let Some(button) = GamepadButton::from_raw(SDL_GameControllerButton(
+                        event.cbutton.button as i32,
+                    )) {
+                        return Some(Event::ControllerButtonUp {
+                            joystick: JoystickID::from_raw(event.cdevice.which),
+                            button,
+                        });
+                    }
+                }
+
+                SDL_CONTROLLERAXISMOTION => {
+                    if let Some(axis) =
+                        GamepadAxis::from_raw(SDL_GameControllerAxis(event.caxis.axis as i32))
+                    {
+                        let mut value = if event.caxis.value > 0 {
+                            event.caxis.value as f32 / 32767.0
+                        } else {
+                            event.caxis.value as f32 / 32768.0
+                        };
+
+                        // TODO: Add less hacky deadzone logic
+                        if value.abs() < 0.2 {
+                            value = 0.0;
+                        }
+                        return Some(Event::ControllerAxisMotion {
+                            joystick: JoystickID::from_raw(event.cdevice.which),
+                            axis,
+                            value,
+                        });
+                    }
+                }
+
+                _ => {}
+            }
+        }
+        None
+    }
+}

--- a/src/input/event.rs
+++ b/src/input/event.rs
@@ -60,6 +60,10 @@ pub enum Event {
         width: u32,
         height: u32,
     },
+
+    TextInput {
+        text: String,
+    },
 }
 
 impl Event {
@@ -168,6 +172,14 @@ impl Event {
                         let height = e.data2 as u32;
                         return Some(Event::WindowResized { width, height });
                     }
+                }
+
+                SDL_TEXTINPUT => {
+                    let e = &event.text.text;
+                    let text = std::ffi::CStr::from_ptr(e.as_ptr())
+                        .to_string_lossy()
+                        .into_owned();
+                    return Some(Event::TextInput { text });
                 }
 
                 _ => {}

--- a/src/input/event.rs
+++ b/src/input/event.rs
@@ -56,6 +56,10 @@ pub enum Event {
         axis: GamepadAxis,
         value: f32,
     },
+    WindowResized {
+        width: u32,
+        height: u32,
+    },
 }
 
 impl Event {
@@ -154,6 +158,15 @@ impl Event {
                             axis,
                             value,
                         });
+                    }
+                }
+
+                SDL_WINDOWEVENT => {
+                    let e = &event.window;
+                    if e.data1 > 0 && e.data2 > 0 {
+                        let width = e.data1 as u32;
+                        let height = e.data2 as u32;
+                        return Some(Event::WindowResized { width, height });
                     }
                 }
 

--- a/src/input/gamepad.rs
+++ b/src/input/gamepad.rs
@@ -1,16 +1,33 @@
+use std::{fmt, rc::Rc};
+
 use fermium::prelude::*;
 
-pub(crate) struct Gamepad {
+#[derive(Clone)]
+pub struct Gamepad(#[allow(dead_code)] Rc<GamepadInner>);
+
+impl PartialEq for Gamepad {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl fmt::Debug for Gamepad {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Gamepad(...)")
+    }
+}
+
+struct GamepadInner {
     handle: *mut SDL_GameController,
 }
 
 impl Gamepad {
     pub fn from_raw(raw: *mut SDL_GameController) -> Gamepad {
-        Gamepad { handle: raw }
+        Gamepad(Rc::new(GamepadInner { handle: raw }))
     }
 }
 
-impl Drop for Gamepad {
+impl Drop for GamepadInner {
     fn drop(&mut self) {
         unsafe {
             SDL_GameControllerClose(self.handle);

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -25,6 +25,7 @@ keys! {
     Tab => SDL_SCANCODE_TAB,
     CapsLock => SDL_SCANCODE_CAPSLOCK,
     Escape => SDL_SCANCODE_ESCAPE,
+    Delete => SDL_SCANCODE_DELETE,
 
     LeftShift => SDL_SCANCODE_LSHIFT,
     RightShift => SDL_SCANCODE_RSHIFT,

--- a/src/input/key.rs
+++ b/src/input/key.rs
@@ -27,8 +27,13 @@ keys! {
     Escape => SDL_SCANCODE_ESCAPE,
 
     LeftShift => SDL_SCANCODE_LSHIFT,
+    RightShift => SDL_SCANCODE_RSHIFT,
     LeftCtrl => SDL_SCANCODE_LCTRL,
+    RightCtrl => SDL_SCANCODE_RCTRL,
     LeftAlt => SDL_SCANCODE_LALT,
+    RightAlt => SDL_SCANCODE_RALT,
+    LeftCommand => SDL_SCANCODE_LGUI,
+    RightCommand => SDL_SCANCODE_RGUI,
 
     Up => SDL_SCANCODE_UP,
     Down => SDL_SCANCODE_DOWN,

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 pub struct Timer {
+    start_time: Instant,
     last_time: Instant,
     accumulated_time: Duration,
     target_time: Duration,
@@ -12,6 +13,7 @@ impl Timer {
         let target_time = Duration::from_secs_f64(1.0 / tick_rate);
 
         Timer {
+            start_time: Instant::now(),
             last_time: Instant::now(),
             accumulated_time: Duration::ZERO,
             target_time,
@@ -72,5 +74,9 @@ impl Timer {
         if self.accumulated_time > self.max_lag {
             self.accumulated_time = self.max_lag;
         }
+    }
+
+    pub fn total_time(&self) -> Duration {
+        self.start_time.elapsed()
     }
 }


### PR DESCRIPTION
- Adds an `Event` enum that also gets send to the `EventHandler`
- Adds a way to get the total elapsed time since the game started; `app.timer.total_time()`
- Adds a way to get a reference to the underlying `glow` handle
  - I needed to make this an `Arc<>` for https://docs.rs/egui_glow/latest/egui_glow/painter/struct.Painter.html#method.new
- Added a new event `WindowResized` that gets triggered when a window gets resized
- Made `Gamepad` a wrapper around `Rc<GamepadInner>` so this could be cloneable (since it's used in `Event`)
- Added Keys `RightShift`, `RightCtrl`, `RightAlt`, `LeftCommand`, and `RightCommand`
