### PR TITLE
Make sure 'serde' feature also enables 'glam/serde'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ rand = "0.8"
 default = ["ldtk"]
 ldtk = ["serde", "serde_json"]
 static_bundled_build = ["fermium/static_bundled_build"]
+serde = ["dep:serde", "glam/serde"]


### PR DESCRIPTION
This makes it so that if you enable the `serde` feature, structs like `Vec2` correctly implement (de)serialize